### PR TITLE
Point typings to exported declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A three.js camera toolkit for creating interactive 3d stories",
   "main": "dist/three-story-controls.esm.min.js",
   "module": "dist/three-story-controls.esm.min.js",
-  "typings": "./lib/three-story-controls.d.ts",
+  "typings": "dist/three-story-controls.d.ts",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Package does not include lib folder

<img width="396" alt="CleanShot 2022-06-06 at 09 03 46@2x" src="https://user-images.githubusercontent.com/8302959/172166195-8201c5f4-0b99-41c8-8d1e-6903568c1ace.png">

But it does export type declarations in the `dist` folder:

<img width="410" alt="CleanShot 2022-06-06 at 09 04 09@2x" src="https://user-images.githubusercontent.com/8302959/172166239-cb76e78d-48c2-4145-9671-0814374fa851.png">
 